### PR TITLE
Fixed using redis streams without group

### DIFF
--- a/Transport/RedisStreamTransportFactory.php
+++ b/Transport/RedisStreamTransportFactory.php
@@ -28,7 +28,7 @@ class RedisStreamTransportFactory implements TransportFactoryInterface
             );
         }
 
-        list(, $stream, $group, $consumer) = explode('/', $parsedUrl['path']);
+        list(, $stream, $group, $consumer) = array_merge(explode('/', $parsedUrl['path']), [null, null]);
 
         return new RedisStreamTransport($parsedUrl['host'], $parsedUrl['port'], $stream, $group, $consumer);
     }

--- a/Transport/RedisStreamTransportFactory.php
+++ b/Transport/RedisStreamTransportFactory.php
@@ -28,7 +28,11 @@ class RedisStreamTransportFactory implements TransportFactoryInterface
             );
         }
 
-        list(, $stream, $group, $consumer) = array_merge(explode('/', $parsedUrl['path']), [null, null]);
+        $dsnParts = explode('/', $parsedUrl['path']);
+
+        $stream = $dsnParts[1];
+        $group = $dsnParts[2] ?? null;
+        $consumer = $dsnParts[3] ?? null;
 
         return new RedisStreamTransport($parsedUrl['host'], $parsedUrl['port'], $stream, $group, $consumer);
     }


### PR DESCRIPTION
When you have a application which only need to send over the redis stream it should not needed to configure a group and consumer in its dsn. This change allows that the last 2 parameters are set to null if not set.