### PR TITLE
Add conflict for symfony/messenger:^4.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "^7.1",
         "ext-redis": "^4.2",
-        "symfony/messenger": "^4.2",
+        "symfony/messenger": "4.2.*",
         "symfony/config": "^3.4 || ^4.0",
         "symfony/dependency-injection": "^3.4 || ^4.0",
         "symfony/serializer": "^3.4 || ^4.0",


### PR DESCRIPTION
The symfony/messenger:^4.3 will not be compatible with the bundle version 1.0 so it only allow symfony/messenger be installed on 4.2