### PR TITLE
Add configurable message key

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -21,6 +21,7 @@ return PhpCsFixer\Config::create()
         'no_useless_else' => true,
         'no_useless_return' => true,
         'php_unit_strict' => true,
+        'single_line_throw' => false,
         'phpdoc_order' => true,
         'semicolon_after_instruction' => true,
         'strict_comparison' => true,

--- a/Transport/RedisStreamSender.php
+++ b/Transport/RedisStreamSender.php
@@ -36,18 +36,24 @@ class RedisStreamSender implements SenderInterface
      */
     protected $serializer;
 
-    public function __construct(Redis $redis, string $stream, ?SerializerInterface $serializer = null)
+    /**
+     * @var string
+     */
+    private $messageKey;
+
+    public function __construct(Redis $redis, string $stream, ?SerializerInterface $serializer = null, string $messageKey = 'content')
     {
         $this->redis = $redis;
         $this->stream = $stream;
         $this->serializer = $serializer ?? Serializer::create();
+        $this->messageKey = $messageKey;
     }
 
     public function send(Envelope $envelope): Envelope
     {
         $encodedMessage = $this->serializer->encode($envelope);
 
-        $messageId = $this->redis->xAdd($this->stream, '*', ['content' => json_encode($encodedMessage)]);
+        $messageId = $this->redis->xAdd($this->stream, '*', [$this->messageKey => json_encode($encodedMessage)]);
 
         if (!$messageId) {
             throw new \RuntimeException(

--- a/Transport/RedisStreamTransport.php
+++ b/Transport/RedisStreamTransport.php
@@ -65,12 +65,18 @@ class RedisStreamTransport implements TransportInterface
      * @var SerializerInterface
      */
     private $serializer;
+
     /**
      * @var string|null
      */
     private $auth;
 
-    public function __construct(string $host, int $port, string $stream, string $group = '', string $consumer = '', ?SerializerInterface $serializer = null, ?string $auth = null)
+    /**
+     * @var string
+     */
+    private $messageKey;
+
+    public function __construct(string $host, int $port, string $stream, string $group = '', string $consumer = '', ?SerializerInterface $serializer = null, ?string $auth = null, string $messageKey = 'content')
     {
         $this->host = $host;
         $this->port = $port;
@@ -79,6 +85,7 @@ class RedisStreamTransport implements TransportInterface
         $this->consumer = $consumer;
         $this->serializer = $serializer ?? Serializer::create();
         $this->auth = $auth;
+        $this->messageKey = $messageKey;
     }
 
     public function receive(callable $handler): void
@@ -103,13 +110,14 @@ class RedisStreamTransport implements TransportInterface
             $this->stream,
             $this->group,
             $this->consumer,
-            $this->serializer
+            $this->serializer,
+            $this->messageKey
         );
     }
 
     private function getSender(): RedisStreamSender
     {
-        return $this->sender = new RedisStreamSender($this->redis ?? $this->getRedis(), $this->stream, $this->serializer);
+        return $this->sender = new RedisStreamSender($this->redis ?? $this->getRedis(), $this->stream, $this->serializer, $this->messageKey);
     }
 
     private function getRedis(): Redis

--- a/Transport/RedisStreamTransportFactory.php
+++ b/Transport/RedisStreamTransportFactory.php
@@ -30,12 +30,18 @@ class RedisStreamTransportFactory implements TransportFactoryInterface
 
         $dsnParts = explode('/', $parsedUrl['path']);
 
+        $options = [];
+        if (isset($parsedUrl['query'])) {
+            parse_str($parsedUrl['query'], $options);
+        }
+
         $stream = $dsnParts[1];
         $group = $dsnParts[2] ?? '';
         $consumer = $dsnParts[3] ?? '';
         $auth = $parsedUrl['user'] ?? null;
+        $messageKey = $options['messageKey'] ?? 'content';
 
-        return new RedisStreamTransport($parsedUrl['host'], $parsedUrl['port'], $stream, $group, $consumer, null, $auth);
+        return new RedisStreamTransport($parsedUrl['host'], $parsedUrl['port'], $stream, $group, $consumer, null, $auth, $messageKey);
     }
 
     public function supports(string $dsn, array $options): bool


### PR DESCRIPTION
The message key is in symfony/messenger 4.3 `message` instead of `content` so if we want to have a consumer using symfony/messenger 4.2 (used when have a legacy symfony 3  project) we need to make the message key configurable.

For this the sender need to configure also differently when using the symfony 4.3 e.g.:

```yaml
framework:
    messenger:
        serializer:
            # For compatibility with messenger 4.2 we need to use the symfony serializer
            default_serializer: messenger.transport.symfony_serializer
            symfony_serializer:
                format: json
                context: { }
        buses:
            command_bus:
                middleware:
                    # default message_bus without bus name stamp
                    # before:
                    - reject_redelivered_message_middleware
                    - dispatch_after_current_bus
                    - failed_message_processing_middleware
                    # custom
                    # ... add custom middlewares here
                    # after
                    - send_message
                    - handle_message
                default_middleware: false
        routing:
            'HandcraftedInTheAlps\Bundle\RedisTransportBundle\Message\DomainEventMessage':
                senders: ['redis_stream']
        transports:
            redis_stream: 'redis-stream://%env(resolve:REDIS_HOST)%:%env(resolve:REDIS_PORT)%/%env(resolve:REDIS_STREAM)%?serializer=0'
```